### PR TITLE
Remove title from print

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseURL = "/"
 languageCode = "en-us"
-title = "My New Static Site"
+title = "Cheatsheet Maker"
 copyright = ""
 disqusShortname = ""
 enableEmoji = true

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 <main class="row justify-content-center single main">
-  <h1>{{ .Title }}</h1>
+  <h1 class="no-print">{{ .Title }}</h1>
   <section class="page">
     <article class="inner" contenteditable="true" role="textbox">
       {{ .Content }}

--- a/static/scss/page.scss
+++ b/static/scss/page.scss
@@ -56,6 +56,11 @@ $columns: 5;
   outline: 0;
   /* Show a drop shadow beneath each page */
   box-shadow: 0 4px 5px rgba(75, 75, 75, 0.2);
+
+  /* Scale image to fit column */
+  img {
+    width: 100%;
+  }
 }
 
 .inner {


### PR DESCRIPTION
Previously, the h1 heading is also in the printed cheatsheet. Since the `.page` covers the whole A4 size, this causes the cheatsheet to be cropped at the bottom. By removing the heading, the `.page` can now be fit fully in the A4 page.

Alternatively, we can resize the `.page`'s height. (I think not including the title is better though.)